### PR TITLE
Fix tooltip styling and advanced picker options code generation

### DIFF
--- a/filestack_snap/script.js
+++ b/filestack_snap/script.js
@@ -5252,6 +5252,25 @@ function generateJavaScriptPickerCode(options) {
     if (options.modalSize) lines.push(`  modalSize: ${JSON.stringify(options.modalSize)},`);
     if (options.pasteMode) lines.push(`  pasteMode: '${options.pasteMode}',`);
 
+    // Additional advanced options
+    if (options.globalDropZone) lines.push(`  globalDropZone: true,`);
+    if (options.disableAltText) lines.push(`  disableAltText: true,`);
+    if (options.disableDirectoryUpload) lines.push(`  disableDirectoryUpload: true,`);
+    if (options.miniUploader) lines.push(`  miniUploader: true,`);
+    if (options.startUploadingWhenMaxFilesReached) lines.push(`  startUploadingWhenMaxFilesReached: true,`);
+    if (options.disableStorageKey) lines.push(`  disableStorageKey: true,`);
+    if (options.useSentryBreadcrumbs) lines.push(`  useSentryBreadcrumbs: true,`);
+    if (options.viewType) lines.push(`  viewType: '${options.viewType}',`);
+    if (options.videoResolution) lines.push(`  videoResolution: '${options.videoResolution}',`);
+    if (options.container) lines.push(`  container: '${options.container}',`);
+    if (options.customSourceName) lines.push(`  customSourceName: '${options.customSourceName}',`);
+    if (options.customSourcePath) lines.push(`  customSourcePath: '${options.customSourcePath}',`);
+    if (options.customSourceContainer) lines.push(`  customSourceContainer: '${options.customSourceContainer}',`);
+    if (options.rootId) lines.push(`  rootId: '${options.rootId}',`);
+    if (options.supportEmail) lines.push(`  supportEmail: '${options.supportEmail}',`);
+    if (options.googleDriveAppID) lines.push(`  googleDriveAppID: '${options.googleDriveAppID}',`);
+    if (options.errorsTimeout) lines.push(`  errorsTimeout: ${options.errorsTimeout},`);
+
     // storeTo
     if (options.storeTo) {
         lines.push(`  storeTo: ${JSON.stringify(options.storeTo, null, 2).replace(/\n/g, '\n  ')},`);

--- a/filestack_snap/styles.css
+++ b/filestack_snap/styles.css
@@ -1309,19 +1309,49 @@ input[type="range"]::-moz-range-thumb {
     bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    background: #333;
-    color: white;
-    padding: 0.5rem 1rem;
+    background: #2c3e50;
+    color: #ffffff !important;
+    padding: 0.75rem 1rem;
     border-radius: 6px;
-    font-size: 0.8rem;
-    white-space: nowrap;
+    font-size: 0.875rem !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
+    font-weight: 400 !important;
+    line-height: 1.6;
+    white-space: normal !important;
+    word-wrap: break-word;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    text-transform: none !important;
+    letter-spacing: normal !important;
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.05s ease;
-    z-index: 1000;
+    transition: opacity 0.2s ease;
+    z-index: 10000;
+    min-width: 220px;
+    max-width: 350px;
+    width: max-content;
+    text-align: left;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    margin-bottom: 0.5rem;
 }
 
-.tooltip:hover::after {
+.tooltip::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #2c3e50;
+    margin-bottom: -6px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 10000;
+}
+
+.tooltip:hover::after,
+.tooltip:hover::before {
     opacity: 1;
 }
 


### PR DESCRIPTION
1. Fix tooltip styling in File Picker sections:
   - Changed .tooltip::after to use white-space: normal (was nowrap) to enable proper text wrapping
   - Added proper font-family, text-transform: none, and letter-spacing: normal with !important to override inherited styles
   - Increased max-width from no limit to 350px for better readability
   - Added min-width of 220px and improved padding/spacing
   - Added .tooltip::before for arrow indicator
   - Changed background color to #2c3e50 for better contrast
   - Enhanced box-shadow and z-index for proper layering

2. Fix advanced picker options not appearing in generated code:
   - Added 18 missing advanced options to generateJavaScriptPickerCode(): globalDropZone, disableAltText, disableDirectoryUpload, miniUploader, startUploadingWhenMaxFilesReached, disableStorageKey, useSentryBreadcrumbs, viewType, videoResolution, container, customSourceName, customSourcePath, customSourceContainer, rootId, supportEmail, googleDriveAppID, errorsTimeout
   - These options were being collected but not included in code output