### PR TITLE
Create 3-column layout with left sidebar for credentials and navigation

### DIFF
--- a/filestack_snap/script.js
+++ b/filestack_snap/script.js
@@ -9860,7 +9860,15 @@ function createCredentialsSidebar() {
     content.appendChild(signatureGroup);
 
     sidebar.appendChild(content);
-    document.body.appendChild(sidebar);
+
+    // Create or get left sidebar container
+    let leftSidebar = document.querySelector('.left-sidebar-container');
+    if (!leftSidebar) {
+        leftSidebar = document.createElement('div');
+        leftSidebar.className = 'left-sidebar-container';
+        document.body.appendChild(leftSidebar);
+    }
+    leftSidebar.appendChild(sidebar);
 }
 
 function initializeSectionNavigator() {
@@ -9878,7 +9886,14 @@ function initializeSectionNavigator() {
         if (configCards.length >= 5) {
             if (!navigator) {
                 navigator = createSectionNavigator(configCards);
-                document.body.appendChild(navigator);
+                // Append to left sidebar container
+                let leftSidebar = document.querySelector('.left-sidebar-container');
+                if (!leftSidebar) {
+                    leftSidebar = document.createElement('div');
+                    leftSidebar.className = 'left-sidebar-container';
+                    document.body.appendChild(leftSidebar);
+                }
+                leftSidebar.appendChild(navigator);
             } else {
                 // Update existing navigator for new section
                 updateSectionNavigator(navigator, configCards);
@@ -9910,7 +9925,14 @@ function initializeSectionNavigator() {
         const configCards = activeSection.querySelectorAll('.config-card');
         if (configCards.length >= 5) {
             const navigator = createSectionNavigator(configCards);
-            document.body.appendChild(navigator);
+            // Append to left sidebar container
+            let leftSidebar = document.querySelector('.left-sidebar-container');
+            if (!leftSidebar) {
+                leftSidebar = document.createElement('div');
+                leftSidebar.className = 'left-sidebar-container';
+                document.body.appendChild(leftSidebar);
+            }
+            leftSidebar.appendChild(navigator);
             setTimeout(() => {
                 navigator.classList.add('visible');
                 document.body.classList.add('sidebar-visible');

--- a/filestack_snap/styles.css
+++ b/filestack_snap/styles.css
@@ -132,19 +132,36 @@ body {
     font-size: 1rem;
 }
 
-/* Credentials Sidebar (Left, Above Jump to Section) */
-.credentials-sidebar {
+/* Left Sidebar Container */
+.left-sidebar-container {
     position: fixed;
-    left: 20px;
-    top: 180px;
-    width: 220px;
+    left: 0;
+    top: 80px;
+    width: 260px;
+    height: calc(100vh - 80px);
+    background: #f8f9fa;
+    border-right: 1px solid var(--border-color);
+    overflow-y: auto;
+    overflow-x: hidden;
+    z-index: 100;
+    padding: 20px;
+}
+
+/* Credentials Sidebar (Top of Left Sidebar) */
+.credentials-sidebar {
+    position: sticky;
+    top: 0;
+    left: 0;
+    width: 100%;
+    max-width: 220px;
     background: white;
     border-radius: 12px;
     padding: 0;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    z-index: 101;
+    z-index: 10;
     overflow: hidden;
     border: 2px solid var(--primary-orange);
+    margin-bottom: 20px;
 }
 
 .credentials-header {
@@ -334,12 +351,8 @@ body {
     border-radius: 12px;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
     overflow-y: auto;
+    margin-left: 280px; /* Always account for left sidebar */
     transition: margin-left 0.3s ease;
-}
-
-/* Add left margin when sidebar is visible */
-body.sidebar-visible .main-content {
-    margin-left: 260px;
 }
 
 .content-section {
@@ -2684,20 +2697,15 @@ textarea:focus {
 
 /* Section Navigator (LEFT SIDEBAR - sticky throughout page) */
 .section-navigator {
-    position: fixed;
-    left: 20px;
-    top: 460px; /* Below credentials sidebar (180px top + ~260px height + 20px gap) */
-    width: 220px;
-    max-height: calc(100vh - 480px);
+    position: relative;
+    width: 100%;
+    max-width: 220px;
     background: white;
     border: 1px solid var(--border-color);
     border-radius: 12px;
     padding: 1rem;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    z-index: 100;
     display: none; /* Hidden by default, shown via JS on long pages */
-    overflow-y: auto;
-    overflow-x: hidden;
 }
 
 .section-navigator.visible {
@@ -2992,16 +3000,12 @@ textarea:focus {
 
 /* Mobile responsiveness for new elements */
 @media (max-width: 768px) {
-    .credentials-sidebar {
-        display: none !important; /* Hide credentials on mobile */
+    .left-sidebar-container {
+        display: none !important; /* Hide entire left sidebar on mobile */
     }
 
-    .section-navigator {
-        display: none !important; /* Hide sidebar on mobile */
-    }
-
-    body.sidebar-visible .main-content {
-        margin-left: 0; /* Remove margin on mobile */
+    .main-content {
+        margin-left: 0 !important; /* Remove margin on mobile */
     }
 
     .back-to-top {


### PR DESCRIPTION
Fixed overlapping issue by reorganizing the layout into a proper 3-column structure:

1. Left Sidebar (260px fixed):
   - Contains API credentials card (sticky at top)
   - Contains Jump to Section navigator (below credentials)
   - Unified .left-sidebar-container wraps both elements
   - Light gray background (#f8f9fa) with scrollable content

2. Main Content (center):
   - Adjusted to have 280px left margin to account for sidebar
   - No more overlap issues

3. Code Panel (right):
   - Remains unchanged in existing position

Changes:
- Created .left-sidebar-container with fixed positioning
- Updated credentials-sidebar to use sticky positioning within container
- Updated section-navigator to use relative positioning within container
- Modified JavaScript to append both elements to shared container
- Added responsive CSS to hide sidebar and remove margin on mobile
- Removed complex z-index positioning that caused overlaps

The sidebar is now a clean, organized column that stays out of the way of the main navigation and content areas.