### PR TITLE
Make Advanced Picker Options section visible by default

### DIFF
--- a/filestack_snap/index.html
+++ b/filestack_snap/index.html
@@ -619,7 +619,7 @@
                             <h3><i class="fas fa-cogs"></i> Advanced Picker Options</h3>
                             <i class="fas fa-chevron-down collapse-icon"></i>
                         </div>
-                        <div class="collapsible-content collapsed">
+                        <div class="collapsible-content">
                             <p class="card-description" style="margin-top: 1rem;">Advanced configuration options for power users. Most apps won't need these settings.</p>
 
                             <!-- Additional Callbacks -->


### PR DESCRIPTION
Removed 'collapsed' class from Advanced Picker Options section so it's expanded and visible immediately without requiring a click. This makes all the callback options and advanced settings easily discoverable.