### PR TITLE
Use styling_playground.html approach for picker display

### DIFF
--- a/filestack_snap/index.html
+++ b/filestack_snap/index.html
@@ -4902,18 +4902,25 @@ dnd.filstackSdk.picker(options).open();</pre>
                     <div class="styling-preview" style="flex: 1;">
                         <!-- Picker Preview -->
                         <div style="height: 100%; border: 2px solid #e5e7eb; border-radius: 8px; padding: 1.5rem; background: #f9fafb; display: flex; flex-direction: column;">
-                            <div style="margin-bottom: 1rem;">
-                                <h4 style="color: #374151; font-size: 1.1rem; margin: 0 0 0.5rem 0;">
+                            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+                                <h4 style="color: #374151; font-size: 1.1rem; margin: 0;">
                                     <i class="fas fa-eye"></i> Live Preview with Styling
                                 </h4>
-                                <p style="color: #6b7280; font-size: 0.85rem; margin: 0;">
-                                    Click the button below to open the styled picker and see your CSS styles applied
-                                </p>
+                                <!-- View Mode Toggles -->
+                                <div style="display: flex; gap: 0.5rem;">
+                                    <button id="styling-tab-empty" class="styling-view-tab active" style="padding: 0.5rem 1rem; background: #fb923c; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; font-weight: 600; transition: all 0.2s;">
+                                        Drop Zone View
+                                    </button>
+                                    <button id="styling-tab-files" class="styling-view-tab" style="padding: 0.5rem 1rem; background: #fed7aa; color: #7c2d12; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; font-weight: 600; transition: all 0.2s;">
+                                        File List View
+                                    </button>
+                                </div>
                             </div>
-                            <div id="styling-picker-container" style="flex: 1; display: flex; align-items: center; justify-content: center; background: white; border-radius: 4px; border: 2px dashed #d1d5db;">
-                                <button id="open-styled-picker" style="padding: 1rem 2rem; background: #fb923c; color: white; border: none; border-radius: 8px; cursor: pointer; font-size: 1rem; font-weight: 600; display: flex; align-items: center; gap: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.1); transition: all 0.2s;" onmouseover="this.style.background='#ea580c'; this.style.transform='scale(1.05)'" onmouseout="this.style.background='#fb923c'; this.style.transform='scale(1)'">
-                                    <i class="fas fa-palette"></i> Open Styled Picker
-                                </button>
+                            <!-- Picker Container (fixed size like styling_playground.html) -->
+                            <div style="flex: 1; display: flex; align-items: center; justify-content: center; overflow: hidden;">
+                                <div id="styling-picker-container" style="width: 1000px; height: 580px; transform-origin: center; overflow: hidden;">
+                                    <!-- Filestack picker will be rendered here -->
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -5321,14 +5328,9 @@ dnd.filstackSdk.picker(options).open();</pre>
                 // Reset button
                 document.getElementById('styling-reset-all')?.addEventListener('click', () => this.resetAllStyles());
 
-                // Open styled picker button
-                document.getElementById('open-styled-picker')?.addEventListener('click', () => {
-                    if (this.pickerInstance) {
-                        this.pickerInstance.open();
-                    } else {
-                        this.initPicker();
-                    }
-                });
+                // View mode toggle buttons
+                document.getElementById('styling-tab-empty')?.addEventListener('click', () => this.switchPickerView('empty'));
+                document.getElementById('styling-tab-files')?.addEventListener('click', () => this.switchPickerView('files'));
 
                 // Copy code button
                 document.getElementById('styling-copy-code')?.addEventListener('click', () => this.copyGeneratedCode());
@@ -5757,18 +5759,13 @@ dnd.filstackSdk.picker(options).open();</pre>
                         userOptions = collectPickerOptions();
                     }
 
-                    // Use user's options directly - let picker open normally (overlay/modal)
-                    // Don't force it into a container
-                    const pickerOptions = { ...userOptions };
-
-                    // Remove any inline/container settings to let it open as overlay
-                    delete pickerOptions.container;
-                    if (!pickerOptions.displayMode) {
-                        pickerOptions.displayMode = 'overlay'; // Default to overlay modal
-                    }
-
-                    // Always disable background upload for preview
-                    pickerOptions.uploadInBackground = false;
+                    // Use inline mode with fixed container (like styling_playground.html)
+                    const pickerOptions = {
+                        ...userOptions,
+                        container: '#styling-picker-container',
+                        displayMode: 'inline',
+                        uploadInBackground: false
+                    };
 
                     console.log('%c📝 STYLING PREVIEW PICKER OPTIONS:', 'background: #3b82f6; color: white; padding: 4px 8px; font-weight: bold');
                     console.log(pickerOptions);


### PR DESCRIPTION
Applied the same approach as styling_playground.html for showing the picker in the Styling section:

1. Fixed container size: 1000px x 580px (same as playground)
2. Inline mode with container: '#styling-picker-container'
3. Centered in flex container with overflow: hidden
4. Drop Zone View / File List View toggle buttons restored
5. switchPickerView() event listeners restored

Container structure:
- Outer: flex container for centering
- Inner: fixed 1000x580 container for picker
- Uses displayMode: 'inline' with container option

This matches the exact structure from styling_playground.html which was already working well, providing consistent behavior and proper source list visibility.